### PR TITLE
Fix composer warnings about PSR-4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,8 +2,14 @@
 .gitignore export-ignore
 .github export-ignore
 phpcs.xml.dist export-ignore
+phpunit.xml.dist export-ignore
 phpstan.neon.dist export-ignore
 phpstan-baseline.neon export-ignore
 scripts export-ignore
-makefile export-ignore
+Makefile export-ignore
 src/Resources/themes/default/data export-ignore
+.editorconfig export-ignore
+/examples export-ignore
+/locale/Doctum.pot export-ignore
+/tests export-ignore
+CHANGELOG.md export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -11,5 +11,6 @@ src/Resources/themes/default/data export-ignore
 .editorconfig export-ignore
 /examples export-ignore
 /locale/Doctum.pot export-ignore
+/locale/*.po export-ignore
 /tests export-ignore
 CHANGELOG.md export-ignore

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,11 @@
     },
     "autoload": {
         "psr-4": {
-            "Doctum\\": "src/",
+            "Doctum\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
             "Doctum\\Tests\\": "tests/"
         }
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2561,7 +2561,7 @@ parameters:
 			path: tests/Parser/NodeVisitorTest.php
 
 		-
-			message: "#^Call to an undefined method Doctum\\\\Tests\\\\Renderer\\\\RendererTest\\:\\:assertFileDoesNotExist\\(\\)\\.$#"
+			message: "#^Call to an undefined method Doctum\\\\Tests\\\\Renderer\\\\DiffTest\\:\\:assertFileDoesNotExist\\(\\)\\.$#"
 			count: 1
 			path: tests/Renderer/DiffTest.php
 

--- a/tests/Console/CommandHelpTest.php
+++ b/tests/Console/CommandHelpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Doctum\Tests\Command;
+namespace Doctum\Tests\Console;
 
 use Doctum\Console\Command\ParseCommand;
 use Doctum\Console\Command\RenderCommand;

--- a/tests/Console/CommandTest.php
+++ b/tests/Console/CommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types = 1);
 
-namespace Doctum\Tests\Command;
+namespace Doctum\Tests\Console;
 
 use Doctum\Console\Command\ParseCommand;
 use Doctum\Console\Command\RenderCommand;

--- a/tests/Renderer/DiffTest.php
+++ b/tests/Renderer/DiffTest.php
@@ -5,7 +5,7 @@ namespace Doctum\Tests\Renderer;
 use Doctum\Renderer\Diff;
 use Doctum\Tests\AbstractTestCase;
 
-class RendererTest extends AbstractTestCase
+class DiffTest extends AbstractTestCase
 {
 
     public function testIsPhpClass(): void


### PR DESCRIPTION
Class Doctum\Tests\Command\CommandHelpTest located in code-lts/doctum/tests/Console/CommandHelpTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Doctum\Tests\Command\CommandTest located in code-lts/doctum/tests/Console/CommandTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Doctum\Tests\Renderer\RendererTest located in code-lts/doctum/tests/Renderer/DiffTest.php does not comply with psr-4 autoloading standard. Skipping.