### PR TITLE
Fix - Url encoding of version numbers

### DIFF
--- a/src/Resources/themes/default/layout/layout.twig
+++ b/src/Resources/themes/default/layout/layout.twig
@@ -55,7 +55,7 @@
             <form action="#">
                 <select  class="form-control" id="version-switcher" name="version">
                     {% for version in project.versions %}
-                        <option value="{{ path('../' ~ version ~ '/index.html') }}" data-version="{{ version }}">{{ version.longname }}</option>
+                        <option value="{{ path('../' ~ version.urlEncoded ~ '/index.html') }}" data-version="{{ version }}">{{ version.longname }}</option>
                     {% endfor %}
                 </select>
             </form>

--- a/src/Version/Version.php
+++ b/src/Version/Version.php
@@ -31,10 +31,16 @@ class Version
      */
     protected $longname;
 
+    /**
+     * @var string
+     */
+    protected $urlEncoded;
+
     public function __construct(string $name, ?string $longname = null)
     {
         $this->name     = $name;
         $this->longname = null === $longname ? $name : $longname;
+        $this->urlEncoded = rawurlencode($name);
         $this->isFrozen = false;
     }
 

--- a/tests/Console/CommandHelpTest.php
+++ b/tests/Console/CommandHelpTest.php
@@ -21,17 +21,17 @@ class CommandHelpTest extends AbstractTestCase
         $helpContents = 'The <info>parse</info> command parses a project and generates a database' . "\n"
             . 'with API information:' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit parse config/symfony.php</info>' . "\n"
+            . '    <info>php vendor/bin/phpunit parse config/symfony.php</info>' . "\n"
             . "\n"
             . 'The <comment>--force</comment> option forces a rebuild (it disables the' . "\n"
             . 'incremental parsing algorithm):' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit parse config/symfony.php --force</info>' . "\n"
+            . '    <info>php vendor/bin/phpunit parse config/symfony.php --force</info>' . "\n"
             . "\n"
             . 'The <comment>--version</comment> option overrides the version specified' . "\n"
             . 'in the configuration:' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit parse config/symfony.php --version=main</info>';
+            . '    <info>php vendor/bin/phpunit parse config/symfony.php --version=main</info>';
         $this->assertSame(
             $helpContents,
             $command->getProcessedHelp()
@@ -43,17 +43,17 @@ class CommandHelpTest extends AbstractTestCase
         $command      = new RenderCommand();
         $helpContents = 'The <info>render</info> command renders a project as a static set of HTML files:' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit render render config/doctum.php</info>' . "\n"
+            . '    <info>php vendor/bin/phpunit render render config/doctum.php</info>' . "\n"
             . "\n"
             . 'The <comment>--force</comment> option forces a rebuild (it disables the' . "\n"
             . 'incremental rendering algorithm):' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit render render config/doctum.php --force</info>' . "\n"
+            . '    <info>php vendor/bin/phpunit render render config/doctum.php --force</info>' . "\n"
             . "\n"
             . 'The <comment>--version</comment> option overrides the version specified' . "\n"
             . 'in the configuration:' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit render render config/doctum.php --version=main</info>';
+            . '    <info>php vendor/bin/phpunit render render config/doctum.php --version=main</info>';
         $this->assertSame(
             $helpContents,
             $command->getProcessedHelp()
@@ -65,7 +65,7 @@ class CommandHelpTest extends AbstractTestCase
         $command      = new UpdateCommand();
         $helpContents = 'The <info>update</info> command parses and renders a project:' . "\n"
             . "\n"
-            . '    <info>php ./vendor/bin/phpunit update config/symfony.php</info>' . "\n"
+            . '    <info>php vendor/bin/phpunit update config/symfony.php</info>' . "\n"
             . "\n"
             . 'This command is the same as running the parse command followed' . "\n"
             . 'by the render command.';


### PR DESCRIPTION
Semver supports adding build information to version numbers using `+`; `2.0.0+1`.

Within urls, `+` must be encoded as `%2B`, as `+` is interpreted as a space character.

Doctum assumes that version numbers will be safe to use in urls without encoding, as such using build information in a version causes the version-switcher to route to an incorrect url.

This PR aims to fix that (forgive me for i am new to twig). 
It also fixes a few tests that were not passing when i cloned the repo and ran them.

Let me know how you feel about this change, thanks.