### PR TITLE
Fix - Not url encoding the version string used for navigation

### DIFF
--- a/src/Resources/themes/default/layout/layout.twig
+++ b/src/Resources/themes/default/layout/layout.twig
@@ -55,7 +55,7 @@
             <form action="#">
                 <select  class="form-control" id="version-switcher" name="version">
                     {% for version in project.versions %}
-                        <option value="{{ path('../' ~ version ~ '/index.html') }}" data-version="{{ version }}">{{ version.longname }}</option>
+                        <option value="{{ path('../' ~ version|url_encode ~ '/index.html') }}" data-version="{{ version }}">{{ version.longname }}</option>
                     {% endfor %}
                 </select>
             </form>


### PR DESCRIPTION
Me again!

I've resolved the issues outlined in the prior PR #31;

- signed the commits using the correct email
- no longer made the unnecessary changes to the tests
- used the `url_encode` twig filter rather than creating a property on the Version class

Thanks for your input on the changes, and again for the great utility.

Hope my Github naivety wasn't too frustrating :angel: 