### PR TITLE
Don't inject `<br>` tags into `<pre>` examples

### DIFF
--- a/src/Resources/themes/default/class.twig
+++ b/src/Resources/themes/default/class.twig
@@ -154,7 +154,7 @@
         {% for example in method.getExamples() %}
             <tr>
                 <td><pre class="examples">
-                    {{- example|join(' ')|nl2br -}}
+                    {{- example|join(' ') -}}
                 </pre></td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
`<pre>` tags shouldn't have any `<br>`s in them.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/pre