### PR TITLE
Attempt to reload current page in newly-selected version

### DIFF
--- a/src/Resources/themes/default/doctum.js.twig
+++ b/src/Resources/themes/default/doctum.js.twig
@@ -76,8 +76,20 @@ var Doctum = {
         {# Enable the version switcher #}
         var versionSwitcher = document.getElementById('version-switcher');
         if (versionSwitcher !== null) {
-            versionSwitcher.addEventListener('change', function () {
-                window.location = this.value;
+            var currentVersion = versionSwitcher.options[versionSwitcher.selectedIndex].dataset.version;
+            versionSwitcher.addEventListener('change', function (event) {
+                var targetVersion = event.target.options[event.target.selectedIndex].dataset.version;
+                var candidateUrl = window.location.pathname.replace(currentVersion, targetVersion);
+                // Check if the page exists before redirecting to it
+                var testRequest = new XMLHttpRequest();
+                testRequest.open('HEAD', candidateUrl, false);
+                testRequest.send();
+                if (testRequest.status < 200 || testRequest.status > 399) {
+                    window.location = candidateUrl;
+                } else {
+                    // otherwise reroute to the home page of the new version
+                    window.location = this.value;
+                }
             });
         }
         {% endif %}


### PR DESCRIPTION
Inspired by https://github.com/silverstripe/api.silverstripe.org/issues/106

_Most_ of the time when I toggle the version switcher, I'm hoping to see the page I am currently on, but in a different version.

This PR attempts to do that, rather then defaulting to the homepage of the newly-selected version.