### PR TITLE
fix: loop over forward slashes for relative dir, replace after urlencode

### DIFF
--- a/src/Resources/themes/default/layout/layout.twig
+++ b/src/Resources/themes/default/layout/layout.twig
@@ -69,7 +69,7 @@
                 <select class="form-control" id="version-switcher" name="version">
                     {% for version in project.versions %}
                         <option
-                            value="{{ path('../' ~ version|url_encode ~ '/index.html') }}"
+                            value="{% for i in project.version|split('/') %}../{% endfor %}{{ path(version|url_encode|replace({ '%2F': '/' }) ~ '/index.html') }}"
                             data-version="{{ version }}" {{ version == project.version ? 'selected' : ''}}>{{ version.longname }}</option>
                     {% endfor %}
                 </select>


### PR DESCRIPTION
Closes #63 

- Loops over forward slashes for "../" relative path.
- Replaces URL-encoded forward slashes with the original slash.